### PR TITLE
新規登録ページ(register.php)へのリンク実装済み

### DIFF
--- a/views/users/login.php
+++ b/views/users/login.php
@@ -42,6 +42,7 @@
               <div class="col-sm-4"></div>
               <div class="col-sm-8">
                 <button type="submit" class="btn form-btn">Login</button>
+                <a href="/b_map/users/register" class="btn form-btn">Register</a>
               </div>
 
             </div>


### PR DESCRIPTION
新規登録ページへのリンクがなかったので、ログインページから飛べるようにしました。
優先順位は下の下です。(リンクボタンを一つ設置するだけなので。)